### PR TITLE
Add action to build project on push and on PRs

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/Parsinator.Sample/Parsinator.Sample.csproj
+++ b/Parsinator.Sample/Parsinator.Sample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/Parsinator.Sample/Parsinator.Sample.csproj
+++ b/Parsinator.Sample/Parsinator.Sample.csproj
@@ -4,6 +4,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Parsinator.Tests/ParseTests.DataSet.cs
+++ b/Parsinator.Tests/ParseTests.DataSet.cs
@@ -64,7 +64,7 @@ Street name: Main; City: Wonderland");
 
             var xml = parsed.ToDataSet(ds).GetXml();
 
-            Assert.AreEqual(@"<Person>
+            XmlAssert.AreEqual(@"<Person>
   <FullName Name=""John"" LastName=""Doe"" />
   <Address StreetName=""Main"" City=""Wonderland"" />
 </Person>", xml);
@@ -84,7 +84,6 @@ Street name: Main; City: Wonderland");
                             .WithColumn("StreetName")
                             .WithColumn("City"))
                         .WithRelation("PersonalInformation", "Address");
-
 
             var p = new Dictionary<String, IList<IParse>>
             {
@@ -114,7 +113,7 @@ Street name: Main; City: Wonderland");
 
             var xml = parsed.ToDataSet(ds).GetXml();
 
-            Assert.AreEqual(@"<Person>
+            XmlAssert.AreEqual(@"<Person>
   <PersonalInformation>
     <FullName Name=""John"" LastName=""Doe"" />
     <Address StreetName=""Main"" City=""Wonderland"" />
@@ -175,7 +174,7 @@ State: Somewhere; Country: United States of Wonderland");
 
             var xml = parsed.ToDataSet(ds).GetXml();
 
-            Assert.AreEqual(@"<Person>
+            XmlAssert.AreEqual(@"<Person>
   <FullName Name=""John"" LastName=""Doe"">
     <Address StreetName=""Main"" City=""Wonderland"">
       <Country State=""Somewhere"" Country=""United"" />

--- a/Parsinator.Tests/ParseTests.Details.cs
+++ b/Parsinator.Tests/ParseTests.Details.cs
@@ -32,9 +32,9 @@ namespace Parsinator.Tests
 					"Details",
 					new List<IParse>
 					{
-						new ParseFromRegex(key: "Code", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)$"), factory: (group) => group["1"]),
-						new ParseFromRegex(key: "Name", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)$"), factory: (group) => group["2"]),
-						new ParseFromRegex(key: "Value", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)$"), factory: (group) => group["3"])
+						new ParseFromRegex(key: "Code", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)(.*)$"), factory: (group) => group["1"]),
+						new ParseFromRegex(key: "Name", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)(.*)$"), factory: (group) => group["2"]),
+						new ParseFromRegex(key: "Value", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)(.*)$"), factory: (group) => group["3"])
 					}
 				}
 			};
@@ -84,8 +84,8 @@ Value: 20
 					new List<IParse>
 					{
 						new ParseFromGenerator<int>(key: "Code", seed: 0, next: (current) => current + 1),
-						new ParseFromRegex(key: "Name", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)$"), factory: (group) => group["2"]),
-						new ParseFromRegex(key: "Value", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)$"), factory: (group) => group["3"])
+						new ParseFromRegex(key: "Name", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)(.*)$"), factory: (group) => group["2"]),
+						new ParseFromRegex(key: "Value", pattern: new Regex(@"^(\d)\s*(\w+)\s*(\d+)(.*)$"), factory: (group) => group["3"])
 					}
 				}
 			};

--- a/Parsinator.Tests/Parsinator.Tests.csproj
+++ b/Parsinator.Tests/Parsinator.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/Parsinator.Tests/Parsinator.Tests.csproj
+++ b/Parsinator.Tests/Parsinator.Tests.csproj
@@ -4,6 +4,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Parsinator.Tests/Parsinator.Tests.csproj
+++ b/Parsinator.Tests/Parsinator.Tests.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="XMLUnit.Core" Version="2.7.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Parsinator\Parsinator.csproj" />

--- a/Parsinator.Tests/XmlAssert.cs
+++ b/Parsinator.Tests/XmlAssert.cs
@@ -1,0 +1,16 @@
+﻿using NUnit.Framework;
+using Org.XmlUnit.Builder;
+using Org.XmlUnit.Diff;
+
+namespace Parsinator.Tests
+{
+    public static class XmlAssert
+    {
+        public static void AreEqual(string expected, string actual)
+        {
+            Diff d = DiffBuilder.Compare(Input.FromString(expected))
+                        .WithTest(actual).Build();
+            Assert.IsFalse(d.HasDifferences());
+        }
+    }
+}

--- a/Parsinator/Parsinator.csproj
+++ b/Parsinator/Parsinator.csproj
@@ -7,4 +7,10 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>unstructured-text structured-text parsing csharp</PackageTags>
     </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Parsinator
 
+![](https://img.shields.io/badge/netstandard-2.0-brightgreen.svg) ![](https://github.com/canro91/Parsinator/workflows/Build/badge.svg) ![](https://img.shields.io/github/license/canro91/Parsinator)
+
 Parsinator turns structured and unstructured text into a header-detail representation. You could use Parsinator to create an xml file from a pdf file, an object from a printer spool file or to parse relevant data from any text.
 
 ## Why


### PR DESCRIPTION
* It adds `ReferenceAssemblies` to make Parsinator compile on Linux with v461. As shown [here](https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies) and [here](https://andrewlock.net/using-reference-assemblies-to-build-net-framework-libararies-on-linux-without-mono/)
* It changes `TargetFramework` for test projects to netcoreapp3.1
* It uses [XMLUnit](https://github.com/xmlunit/xmlunit.net) to assert on xml files