### PR TITLE
Use IEnumerable in Parsers, Skippers and Transformations

### DIFF
--- a/Parsinator.Sample/BookTests.cs
+++ b/Parsinator.Sample/BookTests.cs
@@ -99,7 +99,7 @@ Contents
                 Skip.BlankLines
             };
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "GeneralInfo",
@@ -115,7 +115,7 @@ Contents
             var transformation = new TransformFromSingleSkip(
                 Skip.IfDoesNotMatch(new Regex(@"^(\s*)CHAPTER(.*)")));
 
-            var d = new Dictionary<String, IList<IParse>>
+            var d = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Chapter",
@@ -137,7 +137,7 @@ Contents
             Assert.AreEqual(ExpectedXml, xml);
         }
 
-        private List<List<String>> FromText(String str)
+        private List<List<string>> FromText(string str)
         {
             return new List<List<string>> { str.Split(new string[] { Environment.NewLine }, StringSplitOptions.None).Skip(1).ToList() };
         }

--- a/Parsinator.Sample/FrameTests.cs
+++ b/Parsinator.Sample/FrameTests.cs
@@ -14,7 +14,7 @@ namespace Parsinator.Sample
         {
             var frame = "242400676315802812345699553131333035392E30302C412C313032342E37363537392C4E2C30373532382E30313237392C572C302E3030302C2C3235303131377C31322E327C3139347C303030307C303030302C303030307C3032383033303433395BF80D0A";
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -50,7 +50,7 @@ namespace Parsinator.Sample
         {
             var frame = "242400676315802812345699553131333035392E30302C412C313032342E37363537392C4E2C30373532382E30313237392C572C302E3030302C2C3235303131377C31322E327C3139347C303030307C303030302C303030307C3032383033303433395BF80D0A";
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -117,7 +117,7 @@ namespace Parsinator.Sample
         {
             var frame = "24240064621700171234569999013135323331342C412C313032322E373936332C4E2C30373532392E303135312C572C3030302C3333322C3139303731377C31322E327C3139347C304230307C303030302C303439387C3030303030303030324BAA0D0A";
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",

--- a/Parsinator.Sample/InvoiceTest.cs
+++ b/Parsinator.Sample/InvoiceTest.cs
@@ -10,7 +10,7 @@ namespace Parsinator.Sample
     [TestFixture]
     public class InvoiceTest
     {
-        private readonly String InputFile = @"
+        private readonly string InputFile = @"
 +-------------------------------------------------------------------------------------------------------------------------------------+
 |                                                             STARK INDUSTRIES                                                        |
 +-------------------------------------------------------------------------------------------------------------------------------------+
@@ -27,7 +27,7 @@ namespace Parsinator.Sample
 |                                                                                                           |          1,000,000.00   |
 +-----------------------------------------------------------------------------------------------------------+-------------------------+";
 
-        private readonly String ExpectedXml = @"<Invoice>
+        private readonly string ExpectedXml = @"<Invoice>
   <Billing Number=""1000"" Date=""2015-04-15"" Total=""1,000,000.00"" />
   <Customer Name=""James Rhodey Rhodes"">
     <Address AddressLine=""1-23 Main St."" City=""Los Angeles"" />
@@ -70,7 +70,7 @@ namespace Parsinator.Sample
                 new SkipIfMatches(new Regex(@"(\+([\-\+])+\+)"))
             };
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Billing",
@@ -112,7 +112,7 @@ namespace Parsinator.Sample
                     after: new Regex(@"\|\s+\|\s+T O T A L\s+\|")));
 
             var detailRegex = new Regex(@"\|\s+(?<Code>[\w\-]+)\s+(?<Description>[\w\s]{1,48})\s+(?<Quantity>\d+)\s+(?<UnitPrice>[\d\,\.]+)\s+(?<Total>[\d\,\.]+)\s+\|");
-            var d = new Dictionary<String, IList<IParse>>
+            var d = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Product",
@@ -137,7 +137,7 @@ namespace Parsinator.Sample
             Assert.AreEqual(ExpectedXml, xml);
         }
 
-        private List<List<String>> FromText(String str)
+        private List<List<string>> FromText(string str)
         {
             return new List<List<string>> { str.Split(new string[] { Environment.NewLine }, StringSplitOptions.None).Skip(1).ToList() };
         }

--- a/Parsinator.Tests/Fluent/ParseTests.cs
+++ b/Parsinator.Tests/Fluent/ParseTests.cs
@@ -13,7 +13,7 @@ namespace Parsinator.Tests.Fluent
         [Test]
         public void Parse_LineMatchesRegex_ParsesMatchedValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -36,7 +36,7 @@ Value: 123456");
         [Test]
         public void Parse_AnyInput_ReturnsGivenValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -58,7 +58,7 @@ Value: 123456");
         [Test]
         public void Parse_MultipleLineStringUntilRegex_ParsesStringFromLineNumberUntilRegex()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -82,7 +82,7 @@ Value: 123456");
         [Test]
         public void Parse_PatternAndLineNumber_ParsesRegexInTheLine()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -106,7 +106,7 @@ Value: 123456");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexes()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -133,7 +133,7 @@ This line will be ignored");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexesIncludingFirst()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -160,7 +160,7 @@ This line will be ignored");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexesIncludingSecond()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -187,7 +187,7 @@ This line will be ignored");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexesIncludingFirstAndSecond()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -214,7 +214,7 @@ This line will be ignored");
         [Test]
         public void Parse_PositionAndCountInLine_ParsesStringInGivenPosition()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -238,7 +238,7 @@ This line will be ignored");
         [Test]
         public void Parse_LineMatchesGivenRegex_ParsesMultipleGroupsInMatchedValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -261,7 +261,7 @@ Value: 12345 67890");
         [Test]
         public void Parse_LineSeparatedByComma_ParsesValuesBetweenCommas()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -287,7 +287,7 @@ Value: 123456, Result: Foo");
         [Test]
         public void Parse_GivenPageAndMatchingPattern_ParsesPatternFromGivenPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -309,12 +309,12 @@ Value: 123456, Result: Foo");
             Assert.AreEqual("123456", ds["Key"]["Value"]);
         }
 
-        private List<List<String>> FromText(String str)
+        private List<List<string>> FromText(string str)
         {
             return new List<List<string>> { str.Split(new string[] { Environment.NewLine }, StringSplitOptions.None).Skip(1).ToList() };
         }
 
-        private List<List<String>> FromPagesText(params String[] str)
+        private List<List<string>> FromPagesText(params string[] str)
         {
             return str.Select(t => t.Split(new string[] { Environment.NewLine }, StringSplitOptions.None).ToList()).ToList();
         }

--- a/Parsinator.Tests/Fluent/SkipTests.cs
+++ b/Parsinator.Tests/Fluent/SkipTests.cs
@@ -13,7 +13,7 @@ namespace Parsinator.Tests.Fluent
         [Test]
         public void Parse_SkipBeforeRegexAndAfterRegex_DoNotParseTextBeforeOrAfterRegexes()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -45,7 +45,7 @@ Value: 654321
         [Test]
         public void Parse_SkipLineCountFromLineNumber_DoNotParseValueInLinesInRange()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -74,7 +74,7 @@ Value: 654321
         [Test]
         public void Parse_SkipFromFirstRegexToLastRegex_DoNotParseValueBetweenRegexes()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",

--- a/Parsinator.Tests/ParseTests.DataSet.cs
+++ b/Parsinator.Tests/ParseTests.DataSet.cs
@@ -36,7 +36,7 @@ namespace Parsinator.Tests
                             .WithColumn("StreetName")
                             .WithColumn("City"));
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "FullName",
@@ -85,7 +85,7 @@ Street name: Main; City: Wonderland");
                             .WithColumn("City"))
                         .WithRelation("PersonalInformation", "Address");
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "FullName",
@@ -137,7 +137,7 @@ Street name: Main; City: Wonderland");
                         .WithRelation("FullName", "Address")
                         .WithRelation("Address", "Country");
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "FullName",
@@ -190,7 +190,7 @@ State: Somewhere; Country: United States of Wonderland");
                         .WithTable(new DataTable("NotExistingTableName")
                             .WithColumn("ColumnName"));
 
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",

--- a/Parsinator.Tests/ParseTests.Details.cs
+++ b/Parsinator.Tests/ParseTests.Details.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -10,7 +9,7 @@ namespace Parsinator.Tests
 		[Test]
 		public void Parse_Details_ApplyDetailsInEveryLine()
 		{
-			var p = new Dictionary<String, IList<IParse>>
+			var p = new Dictionary<string, IEnumerable<IParse>>
 			{
 				{
 					"Header",
@@ -26,7 +25,7 @@ namespace Parsinator.Tests
 								before: new Regex(@"-- Details --"),
 								after: new Regex(@"-- End of Details --")));
 
-			var d = new Dictionary<String, IList<IParse>>
+			var d = new Dictionary<string, IEnumerable<IParse>>
 			{
 				{
 					"Details",
@@ -61,7 +60,7 @@ Value: 20
 		[Test]
 		public void Parse_Details_ApplyDetailsInEveryLine2()
 		{
-			var p = new Dictionary<String, IList<IParse>>
+			var p = new Dictionary<string, IEnumerable<IParse>>
 			{
 				{
 					"Header",
@@ -77,7 +76,7 @@ Value: 20
 								before: new Regex(@"-- Details --"),
 								after: new Regex(@"-- End of Details --")));
 
-			var d = new Dictionary<String, IList<IParse>>
+			var d = new Dictionary<string, IEnumerable<IParse>>
 			{
 				{
 					"Details",

--- a/Parsinator.Tests/ParseTests.Page.cs
+++ b/Parsinator.Tests/ParseTests.Page.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -11,7 +10,7 @@ namespace Parsinator.Tests
         [Test]
         public void Parse_GivenPageAndMatchingPattern_ParsesPatternFromGivenPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -36,7 +35,7 @@ namespace Parsinator.Tests
         [Test]
         public void Parse_GivenNegativePageAndMatchingPattern_ParsesPatternFromLastPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -60,7 +59,7 @@ namespace Parsinator.Tests
         [Test]
         public void Parse_GivenNegativePageAndSinglePageText_ParsesPatternFromLastPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -83,7 +82,7 @@ Value: 123456");
         [Test]
         public void Parse_ParserWithoutPage_ParsesPatternInFirstPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -109,7 +108,7 @@ Value: 123456");
         [Test]
         public void Parse_SingleParserWithPageAndPatternInMultiplePages_ParsesPatternOnlyInGivenPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -133,7 +132,7 @@ Value: 123456");
         [Test]
         public void Parse_RequiredInnerParserWithPageAndValueParsed_DoesNotThrowException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -158,7 +157,7 @@ Value: 123456");
         [Test]
         public void Parse_ValidateInnerParserWithPageAndValueParsedThatSatisfyPredicate_ParsesValueAndDoesNotThrowException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -184,7 +183,7 @@ Value: 123456");
         [Test]
         public void Parse_OrElseAndMatchInTheFirstParserWithPage_ParsesValueFromFirstParserInGivenPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -211,7 +210,7 @@ Value: 123456");
         [Test]
         public void Parse_OrElseAndMatchInTheSecondParserWithPage_ParsesValueFromFirstParserInGivenPage()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -238,7 +237,7 @@ Value: 123456");
         [Test]
         public void Parse_AndThenAndMatchInBothParsersWithPages_ParsersValueFromBothParsersInGivenPages()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -266,7 +265,7 @@ Value: 123456");
         [Test]
         public void Parse_ConcatenateTwoPagedParsers_ParsersValueFromBothParsersInGivenPages()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -294,7 +293,7 @@ Value: 123456");
         [Test]
         public void Parse_ConcatenateTwoPagedParsersAndNegativePageNumber_ParsersValueFromBothParsersInGivenPages()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -322,7 +321,7 @@ Value: 123456");
         [Test]
         public void Parse_ConcatenateTwoPagedParsersAnNegativePageNumberFirst_ParsersValueFromBothParsersInGivenPages()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",

--- a/Parsinator.Tests/ParseTests.cs
+++ b/Parsinator.Tests/ParseTests.cs
@@ -12,7 +12,7 @@ namespace Parsinator.Tests
         [Test]
         public void Parse_LineMatchesGivenRegex_ParsesMatchedValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -34,7 +34,7 @@ Value: 123456");
         [Test]
         public void Parse_LineDoesNotMatchGivenRegex_ParsesDefaultValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -56,7 +56,7 @@ This line doesn't match the given regex");
         [Test]
         public void Parse_SingleCategoryAndMultipleParses_AppliesMutlipleParsers()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -80,7 +80,7 @@ Value: 123456");
         [Test]
         public void Parse_MultipleCategories_AppliesParsesForEveryCategory()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -109,7 +109,7 @@ Value: 123456");
         [Test]
         public void Parse_MultipleLineStringUntilRegex_ParseStringFromLineNumberUntilRegex()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -133,7 +133,7 @@ value
         [Test]
         public void Parse_MultipleLineStringUntilRegex_ParseStringsAndConcatenateThemByDefault()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -157,7 +157,7 @@ value
         [Test]
         public void Parse_PatternAndLineNumber_ParsesRegexInTheLine()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -181,7 +181,7 @@ value
         [Test]
         public void Parse_PatternInMultipleLinesAndLineNumber_ParsesRegexInTheGivenLine()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -205,7 +205,7 @@ value
         [Test]
         public void Parse_PatternAndNegativeLineNumber_ParsesRegexInTheLineFromBottom()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -229,7 +229,7 @@ value
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexes()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -256,7 +256,7 @@ This line will be ignored");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexesAndConcatenateThemByDefault()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -283,7 +283,7 @@ This line will be ignored");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexesIncludingFirst()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -310,7 +310,7 @@ This line will be ignored");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexesIncludingSecond()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -337,7 +337,7 @@ This line will be ignored");
         [Test]
         public void Parse_MultipleLineStringBetweenTwoRegexes_ParseStringBetweenRegexesIncludingFirstAndSecond()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -364,7 +364,7 @@ This line will be ignored");
         [Test]
         public void Parse_EmpytLineAndFixedValueParser_ParseFixedValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -385,7 +385,7 @@ This line will be ignored");
         [Test]
         public void Parse_NotEmpytLineAndFixedValueParser_ParseFixedValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -407,7 +407,7 @@ Anything");
         [Test]
         public void Parse_PositionAndCountInLine_ParsesStringInGivenPosition()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -431,7 +431,7 @@ Anything");
         [Test]
         public void Parse_PositionAndNegativeCountInLine_ParsesStringWithCountFromEnd()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -455,7 +455,7 @@ Anything");
         [Test]
         public void Parse_PositionAfterHalfLengthAndNegativeCountInLine_ParsesStringWithCountFromEnd()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -480,7 +480,7 @@ Anything");
         [Test]
         public void Parse_NegativePositionAndCountInLine_ParsesStringInPositionFromEnd()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -504,7 +504,7 @@ Anything");
         [Test]
         public void Parse_NegativePositionAndNegativeCountInLine_ParsesStringWithPositionAndCountFromEnd()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -528,7 +528,7 @@ Anything");
         [Test]
         public void Parse_PositionAndZeroCountInLine_DoesNotParse()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -552,7 +552,7 @@ Anything");
         [Test]
         public void Parse_PositionAndCountInLineWithFactory_ParsesAndAppliesFactory()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -576,7 +576,7 @@ Anything");
         [Test]
         public void Parse_OrElseAndMatchInTheFirstParser_ParsesValueFromFirstParser()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -601,7 +601,7 @@ Value: 123456");
         [Test]
         public void Parse_OrElseAndMatchInTheSecondParser_ParsesValueFromSecondParser()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -626,7 +626,7 @@ Result: 123456");
         [Test]
         public void Parse_RequiredAndPatternNotFound_ThrowsException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -649,7 +649,7 @@ This line doesn't match");
         [Test]
         public void Parse_RequiredWithDefaultValueInInnerParser_DoesNotThrowException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -673,7 +673,7 @@ This line doesn't match");
         [Test]
         public void Parse_RequiredAndValueParsed_DoesNotThrowException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -697,7 +697,7 @@ Value: 123456");
         [Test]
         public void Parse_RequiredAndValueToMatchIsNotInFirstLine_ParsesValueAndDoesNotThrowException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -724,7 +724,7 @@ Value: 123456");
         [Test]
         public void Parse_ValidateAndValueParsedThatSatisfyPredicate_ParsesValueAndDoesNotThrowException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -749,7 +749,7 @@ Value: 123456 This value has 6 chars, so it's valid");
         [Test]
         public void Parse_ValidationAndValueParseThatDoesNotSatisfyPredicate_ParsesValueAndThrowsException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -774,7 +774,7 @@ Value: 123456 This value doesn't have more than 10 chars, so it's invalid");
         [Test]
         public void Parse_ExceptionInCustomFactory_ThrowsException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -798,7 +798,7 @@ Value: 123456");
         [Test]
         public void Parse_AndThenAndMatchInBothParsers_ParsersValueFromBothParsers()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -825,7 +825,7 @@ Result: 456");
         [Test]
         public void Parse_AndThenAndFirstParserDoesNotMatch_DoesNotParse()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -852,7 +852,7 @@ Result: 456");
         [Test]
         public void Parse_AndThenAndSecondParserDoesNotMatch_DoesNotParse()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -879,7 +879,7 @@ Result: This line doesn't match");
         [Test]
         public void Parse_AndThenAndMatchInBothParsersInTheSameLine_ParsersValueFromBothParsers()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -905,7 +905,7 @@ Value: 123 Result: 456");
         [Test]
         public void Parse_MatchingParserToParseFrom_ParsesFromOutputOfParser()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -936,7 +936,7 @@ Value: 123 Result: 456");
         public void Parse_NonMatchingParserToParseFrom_DoesNotParseFromOutputOfParser()
         {
             var greatherThanLineLength = 100;
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -966,7 +966,7 @@ Value: 123 Result: 456");
         [Test]
         public void Parse_LineMatchesGivenRegex_ParsesMultipleGroupsInMatchedValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -989,7 +989,7 @@ Value: 12345 67890");
         [Test]
         public void Parse_IfWithMatchingParserAndTruePredicate_ParsesThenParser()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1016,7 +1016,7 @@ Result: 654321");
         [Test]
         public void Parse_IfWithMatchingParserInTheSameLine_ParsesThenParser()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1042,7 +1042,7 @@ Value: 123456 This value has 6 chars, so it's valid Result: 654321");
         [Test]
         public void Parse_IfWithMatchingParserAndTruePredicate_DoesNotAddThenParserIfItDoesNotParse()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1070,7 +1070,7 @@ Result: This line doesn't match");
         [Test]
         public void Parse_IfWithMatchingParserAndFalsePredicate_ParsesElseParser()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1100,7 +1100,7 @@ Foo: Bar");
         [Test]
         public void Parse_IfWithNonMatchingParserAndTruePredicate_DoesNotParseSingleThenParser()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1127,7 +1127,7 @@ Result: 654321");
         [Test]
         public void Parse_SingleMatchingLineAndMultipleNonMatchingLines_ParsesMatchedValueAndStopsParsing()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1154,7 +1154,7 @@ This line doesn't match");
         [Test]
         public void Parse_NotParseAndAMatchingParser_ThrowsException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1177,7 +1177,7 @@ Value: 123456");
         [Test]
         public void Parse_NotParseAndANonMatchingParserWithDefaultValue_ThrowsException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1200,7 +1200,7 @@ This line doesn't match the given regex");
         [Test]
         public void Parse_NotParseAndANonMatchingParserWithoutDefaultValue_DoesNotThrowException()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1222,7 +1222,7 @@ This line doesn't match the given regex");
         [Test]
         public void Parse_TwoMatchingParsers_ParsesValueAndConcatenatesThem()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1249,7 +1249,7 @@ Result: Foo");
         [Test]
         public void Parse_TwoNonMatchingParsersWithDefaultValues_ParsesValueAndConcatenatesDefaultValues()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1276,7 +1276,7 @@ This line doesn't match");
         [Test]
         public void Parse_AMatchingAndNonMatchingParsersWithDefaultValue_ParsesValueAndConcatenatesParsedAndDefaultValues()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1303,7 +1303,7 @@ This line doesn't match");
         [Test]
         public void Parse_LineSeparatedByComma_ParsesValuesBetweenCommas()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -1328,7 +1328,7 @@ Value: 123456, Result: Foo");
         [Test]
         public void Parse_LineSeparatedByCommaAndIgnoreTwoSegments_ParsesValuesAfterTheSecondComma()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",

--- a/Parsinator.Tests/SkipTests.cs
+++ b/Parsinator.Tests/SkipTests.cs
@@ -12,7 +12,7 @@ namespace Parsinator.Tests
         [Test]
         public void Parse_SkipBeforeRegexAndAfterRegex_DoNotParseTextBeforeRegex()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -43,7 +43,7 @@ This line won't be ignored
         [Test]
         public void Parse_SkipBeforeRegexAndAfterRegex_DoNotParseTextAfterRegex()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -74,7 +74,7 @@ Value: 123456
         [Test]
         public void Parse_SkipBeforeRegexAndAfterRegex_ParseTextBetweenRegex()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -104,7 +104,7 @@ Value: 123456
         [Test]
         public void Parse_SkipBlankLines_ParsesTextInNonBlankLines()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -135,7 +135,7 @@ Value: 123456");
         [Test]
         public void Parse_SkipFromFirstMatchOfRegex_DoNotParseValueAfterMatch()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -164,7 +164,7 @@ Value: 123456 This line will be ignored too");
         [Test]
         public void Parse_SkipIfDoesNotMatch_DoNotParseValueInLinesWithMatch()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -193,7 +193,7 @@ This line will be ignored");
         [Test]
         public void Parse_SkipIfDoesNotMatch_ParsesTextInLinesThatDontMatch()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -224,7 +224,7 @@ This line will be ignored
         [Test]
         public void Parse_SkipIfMatches_DoNotParseValueInLinesWithMatch()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -253,7 +253,7 @@ This line will be ignored");
         [Test]
         public void Parse_SkipLineCountFromStart_DoNotParseValueInLinesFromStart()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -282,7 +282,7 @@ This line will be ignored");
         [Test]
         public void Parse_SkipLineCountFromEnd_DoNotParseValueInLinesFromEnd()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -311,7 +311,7 @@ This line will be ignored");
         [Test]
         public void Parse_SkipLineCountFromLineNumber_DoNotParseValueInLinesInRange()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -340,7 +340,7 @@ This line will be ignored");
         [Test]
         public void Parse_SkipFromFirstRegexToLastRegex_DoNotParseValueBetweenRegexes()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -369,7 +369,7 @@ This line will be ignored");
         [Test]
         public void Parse_SkipFromFirstRegexToLastRegex_ParseValueBeforeFirstRegex()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -400,7 +400,7 @@ Value: 654321
         [Test]
         public void Parse_SkipFromFirstRegexToLastRegex_ParseValueAfterLastRegex()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",
@@ -431,7 +431,7 @@ Value: 654321");
         [Test]
         public void Parse_SkipFromFirstRegexToLastRegexWithoutMatchingPattern_ParseValue()
         {
-            var p = new Dictionary<String, IList<IParse>>
+            var p = new Dictionary<string, IEnumerable<IParse>>
             {
                 {
                     "Key",

--- a/Parsinator/Extensions/DataSetExtensions.cs
+++ b/Parsinator/Extensions/DataSetExtensions.cs
@@ -5,7 +5,7 @@ namespace Parsinator
 {
     public static class DataSetExtensions
     {
-        public static DataTable WithColumn(this DataTable table, String name, MappingType type = MappingType.Attribute)
+        public static DataTable WithColumn(this DataTable table, string name, MappingType type = MappingType.Attribute)
         {
             table.Columns.Add(new DataColumn(name, typeof(string)) { ColumnMapping = type });
             return table;
@@ -22,12 +22,12 @@ namespace Parsinator
             return table;
         }
 
-        private static String NameForEmptyColumn(this DataTable table)
+        private static string NameForEmptyColumn(this DataTable table)
         {
             return $"{table.TableName}-Empty";
         }
 
-        public static DataSet WithRelation(this DataSet dataSet, String parentTableName, String childTableName)
+        public static DataSet WithRelation(this DataSet dataSet, string parentTableName, string childTableName)
         {
             if (!dataSet.Tables.Contains(parentTableName))
                 throw new ArgumentNullException($"DataSet [{dataSet.DataSetName}] doesn't contain table [{parentTableName}]");

--- a/Parsinator/Extensions/DictionaryExtensions.cs
+++ b/Parsinator/Extensions/DictionaryExtensions.cs
@@ -46,7 +46,7 @@ namespace Parsinator
             return dataSet;
         }
 
-        internal static Dictionary<String, Dictionary<String, String>> AddOrMerge(this Dictionary<string, Dictionary<string, string>> self, String key, Dictionary<string, string> dict)
+        internal static Dictionary<string, Dictionary<string, string>> AddOrMerge(this Dictionary<string, Dictionary<string, string>> self, String key, Dictionary<string, string> dict)
         {
             if (!self.ContainsKey(key))
                 self[key] = dict;
@@ -60,7 +60,7 @@ namespace Parsinator
             return self;
         }
 
-        internal static IDictionary<String, String> Merge(this IDictionary<String, String> self, IDictionary<string, string> dict)
+        internal static IDictionary<string, string> Merge(this IDictionary<string, string> self, IDictionary<string, string> dict)
         {
             foreach (var item in dict)
             {

--- a/Parsinator/Extensions/IEnumerableExtensions.cs
+++ b/Parsinator/Extensions/IEnumerableExtensions.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Parsinator
 {
     public static class IEnumerableExtensions
     {
-        public static IDictionary<String, String> Enumerate(this IEnumerable<String> self)
+        internal static IDictionary<string, string> Enumerate(this IEnumerable<string> self)
         {
             return self.Select((item, i) => new { Item = item, Index = i })
                        .ToDictionary(k => k.Index.ToString(), v => v.Item);
         }
 
-        public static IDictionary<String, String> Enumerate(this IEnumerable<String> self, string prefix)
+        internal static IDictionary<string, string> Enumerate(this IEnumerable<string> self, string prefix)
         {
             return self.Select((item, i) => new { Item = item, Index = i })
                        .ToDictionary(k => $"{prefix}[{k.Index}]", v => v.Item);

--- a/Parsinator/Extensions/ISkipExtensions.cs
+++ b/Parsinator/Extensions/ISkipExtensions.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Parsinator
 {
     public static class ISkipExtensions
     {
-        public static List<List<String>> Chain(this IList<ISkip> skips, List<List<String>> lines)
+        public static IEnumerable<IEnumerable<string>> Chain(this IEnumerable<ISkip> skips, IEnumerable<IEnumerable<string>> lines)
         {
-            List<List<String>> pages = lines;
+            var pages = lines;
             if (skips != null && skips.Any())
             {
                 foreach (var s in skips)

--- a/Parsinator/Extensions/ISkipExtensions.cs
+++ b/Parsinator/Extensions/ISkipExtensions.cs
@@ -5,7 +5,7 @@ namespace Parsinator
 {
     public static class ISkipExtensions
     {
-        public static IEnumerable<IEnumerable<string>> Chain(this IEnumerable<ISkip> skips, IEnumerable<IEnumerable<string>> lines)
+        internal static IEnumerable<IEnumerable<string>> Chain(this IEnumerable<ISkip> skips, IEnumerable<IEnumerable<string>> lines)
         {
             var pages = lines;
             if (skips != null && skips.Any())

--- a/Parsinator/Extensions/MatchExtensions.cs
+++ b/Parsinator/Extensions/MatchExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -7,7 +6,7 @@ namespace Parsinator
 {
     public static class MatchExtensions
     {
-        public static IDictionary<String, String> Enumerate(this Match matches, Regex pattern)
+        internal static IDictionary<string, string> Enumerate(this Match matches, Regex pattern)
         {
             return pattern.GetGroupNames().ToDictionary(k => k, v => matches.Groups[v].Value);
         }

--- a/Parsinator/IParse.cs
+++ b/Parsinator/IParse.cs
@@ -5,10 +5,10 @@ namespace Parsinator
 {
     public interface IParse
     {
-        String Key { get; }
-        Int32? PageNumber { get; }
+        string Key { get; }
+        int? PageNumber { get; }
         bool HasMatched { get; }
-        Func<String> Default { get; }
-        IDictionary<String, String> Parse(String line, int lineNumber, int lineNumberFromBottom);
+        Func<string> Default { get; }
+        IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom);
     }
 }

--- a/Parsinator/ISkip.cs
+++ b/Parsinator/ISkip.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Parsinator
 {
     public interface ISkip
     {
-        List<List<String>> Skip(List<List<String>> lines);
+        IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines);
     }
 }

--- a/Parsinator/ITransform.cs
+++ b/Parsinator/ITransform.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Parsinator
 {
     public interface ITransform
     {
-        List<String> Transform(List<List<String>> allPages);
+        IEnumerable<string> Transform(IEnumerable<IEnumerable<string>> allPages);
     }
 }

--- a/Parsinator/ParseWithFactory.cs
+++ b/Parsinator/ParseWithFactory.cs
@@ -6,10 +6,10 @@ namespace Parsinator
 {
     public abstract class ParseWithFactory : IParse
     {
-        private readonly Func<IDictionary<String, String>, String> _func;
-        private readonly Func<String, String> _func2;
+        private readonly Func<IDictionary<string, string>, string> _func;
+        private readonly Func<string, string> _func2;
 
-        protected ParseWithFactory(string key, int? pageNumber, Func<IDictionary<String, String>, String> factory, Func<string> @default)
+        protected ParseWithFactory(string key, int? pageNumber, Func<IDictionary<string, string>, string> factory, Func<string> @default)
         {
             Key = key;
             PageNumber = pageNumber;
@@ -18,7 +18,7 @@ namespace Parsinator
             _func = factory;
         }
 
-        protected ParseWithFactory(string key, Func<IDictionary<String, String>, String> factory, Func<string> @default)
+        protected ParseWithFactory(string key, Func<IDictionary<string, string>, string> factory, Func<string> @default)
         {
             Key = key;
             Default = @default;
@@ -26,28 +26,28 @@ namespace Parsinator
             _func = factory;
         }
 
-        protected ParseWithFactory(string key, Func<IDictionary<String, String>, String> factory)
+        protected ParseWithFactory(string key, Func<IDictionary<string, string>, string> factory)
         {
             Key = key;
 
             _func = factory;
         }
 
-        protected ParseWithFactory(string key, Func<String, String> factory)
+        protected ParseWithFactory(string key, Func<string, string> factory)
         {
             Key = key;
 
             _func2 = factory;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; protected set; }
-        public Func<String> Default { get; private set; }
+        public string Key { get; private set; }
+        public int? PageNumber { get; protected set; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; protected set; }
 
         public bool HasFactory => _func != null || _func2 != null;
 
-        protected String Factory(IDictionary<String, String> parsed)
+        protected string Factory(IDictionary<string, string> parsed)
         {
             try
             {
@@ -59,7 +59,7 @@ namespace Parsinator
             }
         }
 
-        protected String Factory(String parsed)
+        protected string Factory(string parsed)
         {
             try
             {
@@ -70,7 +70,6 @@ namespace Parsinator
                 throw new ArgumentException($"Found: {parsed}", Key, e);
             }
         }
-
 
         public abstract IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom);
     }

--- a/Parsinator/Parser.cs
+++ b/Parsinator/Parser.cs
@@ -6,12 +6,12 @@ namespace Parsinator
     public class Parser
     {
         private readonly Dictionary<string, Dictionary<string, string>> _output;
-        private readonly IDictionary<string, IList<IParse>> _headerParsers;
-        private readonly IList<ISkip> _headerSkipers;
+        private readonly IDictionary<string, IEnumerable<IParse>> _headerParsers;
+        private readonly IEnumerable<ISkip> _headerSkipers;
         private readonly ITransform _transform;
-        private readonly IDictionary<string, IList<IParse>> _detailParsers;
+        private readonly IDictionary<string, IEnumerable<IParse>> _detailParsers;
 
-        public Parser(IDictionary<string, IList<IParse>> headerParsers, IList<ISkip> headerSkipers, ITransform transform, IDictionary<string, IList<IParse>> detailParsers)
+        public Parser(IDictionary<string, IEnumerable<IParse>> headerParsers, IEnumerable<ISkip> headerSkipers, ITransform transform, IDictionary<string, IEnumerable<IParse>> detailParsers)
         {
             _headerParsers = headerParsers;
             _headerSkipers = headerSkipers;
@@ -20,12 +20,12 @@ namespace Parsinator
             _output = new Dictionary<string, Dictionary<string, string>>();
         }
 
-        public Parser(IDictionary<string, IList<IParse>> headerParsers, IList<ISkip> headerSkipers)
+        public Parser(IDictionary<string, IEnumerable<IParse>> headerParsers, IEnumerable<ISkip> headerSkipers)
             : this(headerParsers, headerSkipers, null, null)
         {
         }
 
-        public Parser(IDictionary<string, IList<IParse>> headerParsers)
+        public Parser(IDictionary<string, IEnumerable<IParse>> headerParsers)
             : this(headerParsers, new List<ISkip>(), null, null)
         {
         }
@@ -56,7 +56,7 @@ namespace Parsinator
             return _output;
         }
 
-        private IDictionary<string, IEnumerable<IParse>> FindPasersForPage(IDictionary<string, IList<IParse>> parsers, int pageIndex, int totalPages)
+        private IDictionary<string, IEnumerable<IParse>> FindPasersForPage(IDictionary<string, IEnumerable<IParse>> parsers, int pageIndex, int totalPages)
         {
             bool isInPage(IParse t)
                 => (pageIndex == 0)
@@ -101,7 +101,7 @@ namespace Parsinator
             }
         }
 
-        private void ParseInEveryLine(IDictionary<string, IList<IParse>> toParse, IEnumerable<string> page)
+        private void ParseInEveryLine(IDictionary<string, IEnumerable<IParse>> toParse, IEnumerable<string> page)
         {
             foreach (var item in toParse)
             {

--- a/Parsinator/Parser.cs
+++ b/Parsinator/Parser.cs
@@ -1,24 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Parsinator
 {
     public class Parser
     {
-        private readonly Dictionary<String, Dictionary<String, String>> _output;
-        private readonly IDictionary<String, IList<IParse>> _headerParsers;
+        private readonly Dictionary<string, Dictionary<string, string>> _output;
+        private readonly IDictionary<string, IList<IParse>> _headerParsers;
         private readonly IList<ISkip> _headerSkipers;
         private readonly ITransform _transform;
-        private readonly IDictionary<String, IList<IParse>> _detailParsers;
+        private readonly IDictionary<string, IList<IParse>> _detailParsers;
 
-        public Parser(IDictionary<String, IList<IParse>> headerParsers, IList<ISkip> headerSkipers, ITransform transform, IDictionary<String, IList<IParse>> detailParse)
+        public Parser(IDictionary<string, IList<IParse>> headerParsers, IList<ISkip> headerSkipers, ITransform transform, IDictionary<string, IList<IParse>> detailParsers)
         {
             _headerParsers = headerParsers;
             _headerSkipers = headerSkipers;
             _transform = transform;
-            _detailParsers = detailParse;
+            _detailParsers = detailParsers;
             _output = new Dictionary<string, Dictionary<string, string>>();
         }
 
@@ -32,15 +30,15 @@ namespace Parsinator
         {
         }
 
-        public Dictionary<string, Dictionary<string, string>> Parse(List<List<String>> lines)
+        public Dictionary<string, Dictionary<string, string>> Parse(IEnumerable<IEnumerable<string>> lines)
         {
-            List<List<String>> pages = _headerSkipers.Chain(lines);
+            var pages = _headerSkipers.Chain(lines);
 
             // WARNING: To find values from header, the parsers are only applied
             // on the first page, if a page number isn't specified
             foreach (var page in pages.Select((Content, Number) => new { Number, Content }))
             {
-                var parsers = FindPasersForPage(_headerParsers, page.Number, lines.Count);
+                var parsers = FindPasersForPage(_headerParsers, page.Number, lines.Count());
                 if (parsers.Any())
                     ParseOnceInPage(parsers, page.Content);
             }
@@ -48,7 +46,7 @@ namespace Parsinator
             if (_detailParsers != null && _detailParsers.Any())
             {
                 // WARNING: Remove from the equation wrapping lines from page to the next
-                List<String> details = (_transform != null)
+                var details = (_transform != null)
                         ? _transform.Transform(pages)
                         : pages.SelectMany(t => t).ToList();
 
@@ -71,7 +69,7 @@ namespace Parsinator
                     : new Dictionary<string, IEnumerable<IParse>>();
         }
 
-        private void ParseOnceInPage(IDictionary<string, IEnumerable<IParse>> toParse, List<string> page)
+        private void ParseOnceInPage(IDictionary<string, IEnumerable<IParse>> toParse, IEnumerable<string> page)
         {
             foreach (var item in toParse)
             {
@@ -87,7 +85,7 @@ namespace Parsinator
                     // TODO Call only once a parser if it has line number
                     foreach (var parser in parsers.Where(t => !t.HasMatched))
                     {
-                        var result = parser.Parse(line.Content, line.Number + 1, line.Number - page.Count);
+                        var result = parser.Parse(line.Content, line.Number + 1, line.Number - page.Count());
                         if (parser.HasMatched)
                         {
                             row.Merge(result);
@@ -103,7 +101,7 @@ namespace Parsinator
             }
         }
 
-        private void ParseInEveryLine(IDictionary<string, IList<IParse>> toParse, List<string> page)
+        private void ParseInEveryLine(IDictionary<string, IList<IParse>> toParse, IEnumerable<string> page)
         {
             foreach (var item in toParse)
             {
@@ -116,7 +114,7 @@ namespace Parsinator
 
                     foreach (var parser in parsers)
                     {
-                        var result = parser.Parse(line.Content, line.Number + 1, line.Number - page.Count);
+                        var result = parser.Parse(line.Content, line.Number + 1, line.Number - page.Count());
                         if (parser.HasMatched)
                         {
                             row.Merge(result);

--- a/Parsinator/Parsers/AndThen.cs
+++ b/Parsinator/Parsers/AndThen.cs
@@ -11,7 +11,7 @@ namespace Parsinator
         private bool _firstHasMatched;
         private IDictionary<string, string> _firstResult;
 
-        public AndThen(String key, Func<IDictionary<string, string>, string> factory, IParse first, IParse second)
+        public AndThen(string key, Func<IDictionary<string, string>, string> factory, IParse first, IParse second)
             : base(key, factory)
         {
             First = first;
@@ -23,7 +23,7 @@ namespace Parsinator
             _firstResult = new Dictionary<string, string>();
         }
 
-        public AndThen(Func<IDictionary<string, string>, String> factory, IParse first, IParse second)
+        public AndThen(Func<IDictionary<string, string>, string> factory, IParse first, IParse second)
             : this($"{first.Key}&{second.Key}", factory, first, second)
         {
         }
@@ -53,7 +53,7 @@ namespace Parsinator
                 if (Second.HasMatched)
                 {
                     HasMatched = true;
-                    var accumulated = new Dictionary<String, String>(_firstResult).Merge(result2);
+                    var accumulated = new Dictionary<string, string>(_firstResult).Merge(result2);
                     return (HasFactory)
                                 ? new Dictionary<string, string> { { Key, Factory(accumulated) } }
                                 : accumulated;

--- a/Parsinator/Parsers/Concatenate.cs
+++ b/Parsinator/Parsers/Concatenate.cs
@@ -22,8 +22,8 @@ namespace Parsinator
             _results = new Dictionary<IParse, IDictionary<string, string>>();
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber
+        public string Key { get; private set; }
+        public int? PageNumber
         {
             get
             {
@@ -36,7 +36,7 @@ namespace Parsinator
                 return _lastParsedPage;
             }
         }
-        public Func<String> Default
+        public Func<string> Default
         {
             get
             {

--- a/Parsinator/Parsers/IfThen.cs
+++ b/Parsinator/Parsers/IfThen.cs
@@ -6,7 +6,7 @@ namespace Parsinator
 {
     public class IfThen : IParse
     {
-        private readonly Func<String, bool> Predicate;
+        private readonly Func<string, bool> Predicate;
         private readonly IParse If;
         private readonly IParse Then;
         private readonly IParse Else;
@@ -26,14 +26,14 @@ namespace Parsinator
             _output = new Dictionary<string, string>();
         }
 
-        public IfThen(Func<String, bool> predicate, IParse @if, IParse then)
+        public IfThen(Func<string, bool> predicate, IParse @if, IParse then)
             : this(predicate, @if, then, null)
         {
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default
         {
             get
             {

--- a/Parsinator/Parsers/Not.cs
+++ b/Parsinator/Parsers/Not.cs
@@ -13,9 +13,9 @@ namespace Parsinator
             this.P = p;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default
         {
             get
             {

--- a/Parsinator/Parsers/OrElse.cs
+++ b/Parsinator/Parsers/OrElse.cs
@@ -19,9 +19,9 @@ namespace Parsinator
             HasMatched = false;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default { get; private set; }
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; private set; }
 
         public IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)

--- a/Parsinator/Parsers/ParseFromFirstRegexToLastRegex.cs
+++ b/Parsinator/Parsers/ParseFromFirstRegexToLastRegex.cs
@@ -9,10 +9,10 @@ namespace Parsinator
         private readonly Regex FirstPattern;
         private readonly Regex SecondPattern;
 
-        private List<String> _content;
-        private Boolean _hasAtLeastOneMatch;
+        private List<string> _content;
+        private bool _hasAtLeastOneMatch;
 
-        public ParseFromFirstRegexToLastRegex(String key, Regex first, Regex second, Func<IDictionary<String, String>, String> factory, Func<String> @default)
+        public ParseFromFirstRegexToLastRegex(string key, Regex first, Regex second, Func<IDictionary<string, string>, string> factory, Func<string> @default)
             : base(key, factory, @default)
         {
             this.FirstPattern = first;
@@ -22,7 +22,7 @@ namespace Parsinator
             this._hasAtLeastOneMatch = false;
         }
 
-        public ParseFromFirstRegexToLastRegex(String key, Regex first, Regex second)
+        public ParseFromFirstRegexToLastRegex(string key, Regex first, Regex second)
             : this(key, first, second, factory: (allLines) => string.Join(" ", allLines.Values), @default: null)
         {
         }

--- a/Parsinator/Parsers/ParseFromFirstRegexToRegex.cs
+++ b/Parsinator/Parsers/ParseFromFirstRegexToRegex.cs
@@ -9,10 +9,10 @@ namespace Parsinator
         private readonly Regex FirstPattern;
         private readonly Regex SecondPattern;
 
-        private List<String> _content;
-        private Boolean _hasAtLeastOneMatch;
+        private List<string> _content;
+        private bool _hasAtLeastOneMatch;
 
-        public ParseFromFirstRegexToRegex(String key, Regex first, Regex second, Func<IDictionary<String, String>, String> factory, Func<String> @default)
+        public ParseFromFirstRegexToRegex(string key, Regex first, Regex second, Func<IDictionary<string, string>, string> factory, Func<string> @default)
             : base(key, factory, @default)
         {
             this.FirstPattern = first;
@@ -22,7 +22,7 @@ namespace Parsinator
             this._hasAtLeastOneMatch = false;
         }
 
-        public ParseFromFirstRegexToRegex(String key, Regex first, Regex second)
+        public ParseFromFirstRegexToRegex(string key, Regex first, Regex second)
             : this(key, first, second, factory: (allLines) => string.Join(" ", allLines.Values), @default: null)
         {
         }

--- a/Parsinator/Parsers/ParseFromGenerator.cs
+++ b/Parsinator/Parsers/ParseFromGenerator.cs
@@ -8,7 +8,7 @@ namespace Parsinator
         private readonly Func<T, T> Next;
         private T _current;
 
-        public ParseFromGenerator(String key, T seed, Func<T, T> next)
+        public ParseFromGenerator(string key, T seed, Func<T, T> next)
         {
             this.Key = key;
             this.Default = null;
@@ -17,9 +17,9 @@ namespace Parsinator
             this._current = seed;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default { get; private set; }
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; private set; }
 
         public IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)

--- a/Parsinator/Parsers/ParseFromLineNumberUntilFirstMatchOfRegex.cs
+++ b/Parsinator/Parsers/ParseFromLineNumberUntilFirstMatchOfRegex.cs
@@ -9,10 +9,10 @@ namespace Parsinator
         private readonly int LineNumber;
         private readonly Regex Pattern;
 
-        private List<String> _content;
-        private Boolean _hasAtLeastOneMatch;
+        private List<string> _content;
+        private bool _hasAtLeastOneMatch;
 
-        public ParseFromLineNumberUntilFirstMatchOfRegex(String key, int lineNumber, Regex pattern, Func<IDictionary<String, String>, String> factory)
+        public ParseFromLineNumberUntilFirstMatchOfRegex(string key, int lineNumber, Regex pattern, Func<IDictionary<string, string>, string> factory)
             : base(key, factory)
         {
             this.LineNumber = lineNumber;
@@ -22,12 +22,12 @@ namespace Parsinator
             _hasAtLeastOneMatch = false;
         }
 
-        public ParseFromLineNumberUntilFirstMatchOfRegex(String key, int lineNumber, Regex pattern)
+        public ParseFromLineNumberUntilFirstMatchOfRegex(string key, int lineNumber, Regex pattern)
             : this(key: key, lineNumber: lineNumber, pattern: pattern, factory: (allLines) => string.Join(" ", allLines.Values))
         {
         }
 
-        public override IDictionary<String, String> Parse(String line, int lineNumber, int lineNumberFromBottom)
+        public override IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)
         {
             if (lineNumber == this.LineNumber || (this.LineNumber < 0 && lineNumberFromBottom == this.LineNumber))
             {

--- a/Parsinator/Parsers/ParseFromLineNumberWithRegex.cs
+++ b/Parsinator/Parsers/ParseFromLineNumberWithRegex.cs
@@ -9,7 +9,7 @@ namespace Parsinator
         private readonly int LineNumber;
         private readonly Regex Pattern;
 
-        public ParseFromLineNumberWithRegex(String key, int lineNumber, Regex pattern, Func<IDictionary<String, String>, String> factory)
+        public ParseFromLineNumberWithRegex(string key, int lineNumber, Regex pattern, Func<IDictionary<string, string>, string> factory)
             : base(key, factory)
         {
             this.LineNumber = lineNumber;
@@ -21,7 +21,7 @@ namespace Parsinator
         {
         }
 
-        public override IDictionary<String, String> Parse(String line, int lineNumber, int lineNumberFromBottom)
+        public override IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)
         {
             if (lineNumber == this.LineNumber || (this.LineNumber < 0 && lineNumberFromBottom == this.LineNumber))
             {

--- a/Parsinator/Parsers/ParseFromLineWithCountAfterPosition.cs
+++ b/Parsinator/Parsers/ParseFromLineWithCountAfterPosition.cs
@@ -42,7 +42,7 @@ namespace Parsinator
                     var length = (CharCount < 0) ? line.Length + CharCount - startIndex : CharCount;
 
                     var substring = line.Substring(startIndex, length);
-                    var value = (HasFactory) ? Factory(substring) : substring;
+                    var value = HasFactory ? Factory(substring) : substring;
                     return new Dictionary<string, string> { { Key, value.Trim() } };
                 }
             }

--- a/Parsinator/Parsers/ParseFromMultiGroupRegex.cs
+++ b/Parsinator/Parsers/ParseFromMultiGroupRegex.cs
@@ -13,9 +13,10 @@ namespace Parsinator
             this.Key = "";
             this.Pattern = pattern;
         }
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default { get; private set; }
+
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; private set; }
 
         public IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)

--- a/Parsinator/Parsers/ParseFromOutput.cs
+++ b/Parsinator/Parsers/ParseFromOutput.cs
@@ -7,9 +7,9 @@ namespace Parsinator
     public class ParseFromOutput : IParse
     {
         private readonly IParse Parser;
-        private readonly IList<IParse> Parsers;
+        private readonly IEnumerable<IParse> Parsers;
 
-        public ParseFromOutput(IParse parseFrom, List<IParse> parsers)
+        public ParseFromOutput(IParse parseFrom, IEnumerable<IParse> parsers)
         {
             Parser = parseFrom;
             Parsers = parsers;
@@ -30,14 +30,14 @@ namespace Parsinator
 
                 var input = p.Values;
 
-                var innerParsers = new Dictionary<String, IList<IParse>>
+                var innerParsers = new Dictionary<string, IEnumerable<IParse>>
                 {
                     { "_", Parsers }
                 };
                 var parsinator = new Parser(innerParsers);
                 var result = parsinator.Parse(new List<List<string>> { input.ToList() });
 
-                return result.FirstOrDefault().Value ?? new Dictionary<String, String>();
+                return result.FirstOrDefault().Value ?? new Dictionary<string, string>();
             }
             return new Dictionary<string, string>();
         }

--- a/Parsinator/Parsers/ParseFromOutput.cs
+++ b/Parsinator/Parsers/ParseFromOutput.cs
@@ -16,9 +16,9 @@ namespace Parsinator
             PageNumber = parseFrom.PageNumber;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default { get; private set; }
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; private set; }
 
         public IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)

--- a/Parsinator/Parsers/ParseFromRegex.cs
+++ b/Parsinator/Parsers/ParseFromRegex.cs
@@ -8,33 +8,33 @@ namespace Parsinator
     {
         public Regex Pattern { get; private set; }
 
-        public ParseFromRegex(String key, Regex pattern, Int32? pageNumber, Func<IDictionary<String, String>, String> factory, Func<String> @default)
+        public ParseFromRegex(string key, Regex pattern, int? pageNumber, Func<IDictionary<string, string>, string> factory, Func<string> @default)
             : base(key, pageNumber, factory, @default)
         {
             this.Pattern = pattern;
         }
 
-        public ParseFromRegex(String key, Regex pattern, Func<String> @default)
+        public ParseFromRegex(string key, Regex pattern, Func<string> @default)
             : this(key, pattern, null, null, @default)
         {
         }
 
-        public ParseFromRegex(String key, Regex pattern, Func<IDictionary<String, String>, String> factory)
+        public ParseFromRegex(string key, Regex pattern, Func<IDictionary<string, string>, string> factory)
             : this(key, pattern, null, factory, null)
         {
         }
 
-        public ParseFromRegex(String key, Regex pattern, Int32 pageNumber)
+        public ParseFromRegex(string key, Regex pattern, Int32 pageNumber)
             : this(key, pattern, pageNumber, null, null)
         {
         }
 
-        public ParseFromRegex(String key, Regex pattern)
+        public ParseFromRegex(string key, Regex pattern)
             : this(key, pattern, null, null, null)
         {
         }
 
-        public override IDictionary<String, String> Parse(String line, int lineNumber, int lineNumberFromBottom)
+        public override IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)
         {
             // TODO Check pattern is not null
 

--- a/Parsinator/Parsers/ParseFromRegexToLastRegex.cs
+++ b/Parsinator/Parsers/ParseFromRegexToLastRegex.cs
@@ -9,10 +9,10 @@ namespace Parsinator
         private readonly Regex FirstPattern;
         private readonly Regex SecondPattern;
 
-        private List<String> _content;
-        private Boolean _hasAtLeastOneMatch;
+        private List<string> _content;
+        private bool _hasAtLeastOneMatch;
 
-        public ParseFromRegexToLastRegex(String key, Regex first, Regex second, Func<IDictionary<String, String>, String> factory, Func<String> @default)
+        public ParseFromRegexToLastRegex(string key, Regex first, Regex second, Func<IDictionary<string, string>, string> factory, Func<string> @default)
             : base(key, factory)
         {
             this.FirstPattern = first;
@@ -22,7 +22,7 @@ namespace Parsinator
             this._hasAtLeastOneMatch = false;
         }
 
-        public ParseFromRegexToLastRegex(String key, Regex first, Regex second)
+        public ParseFromRegexToLastRegex(string key, Regex first, Regex second)
             : this(key, first, second, factory: (allLines) => string.Join(" ", allLines.Values), @default: null)
         {
         }

--- a/Parsinator/Parsers/ParseFromRegexToRegex.cs
+++ b/Parsinator/Parsers/ParseFromRegexToRegex.cs
@@ -9,10 +9,10 @@ namespace Parsinator
         private readonly Regex FirstPattern;
         private readonly Regex SecondPattern;
 
-        private List<String> _content;
-        private Boolean _hasAtLeastOneMatch;
+        private List<string> _content;
+        private bool _hasAtLeastOneMatch;
 
-        public ParseFromRegexToRegex(String key, Regex first, Regex second, Func<IDictionary<String, String>, String> factory, Func<String> @default)
+        public ParseFromRegexToRegex(string key, Regex first, Regex second, Func<IDictionary<string, string>, string> factory, Func<string> @default)
             : base(key, factory)
         {
             this.FirstPattern = first;
@@ -22,17 +22,17 @@ namespace Parsinator
             this._hasAtLeastOneMatch = false;
         }
 
-        public ParseFromRegexToRegex(String key, Regex first, Regex second, Func<IDictionary<String, String>, String> factory)
+        public ParseFromRegexToRegex(string key, Regex first, Regex second, Func<IDictionary<string, string>, string> factory)
             : this(key: key, first: first, second: second, factory: factory, @default: null)
         {
         }
 
-        public ParseFromRegexToRegex(String key, Regex first, Regex second)
+        public ParseFromRegexToRegex(string key, Regex first, Regex second)
             : this(key: key, first: first, second: second, factory: (allLines) => string.Join(" ", allLines.Values), @default: null)
         {
         }
 
-        public override IDictionary<String, String> Parse(String line, int lineNumber, int lineNumberFromBottom)
+        public override IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)
         {
             // TODO Check pattern is not null
 

--- a/Parsinator/Parsers/ParseFromSplitting.cs
+++ b/Parsinator/Parsers/ParseFromSplitting.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Parsinator
 {
@@ -23,9 +21,9 @@ namespace Parsinator
             this.SkipFirsts = skipFirsts;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default { get; private set; }
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; private set; }
 
         public IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)

--- a/Parsinator/Parsers/ParseFromValue.cs
+++ b/Parsinator/Parsers/ParseFromValue.cs
@@ -11,9 +11,9 @@ namespace Parsinator
             this.Default = () => value;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default { get; private set; }
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; private set; }
 
         public IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)

--- a/Parsinator/Parsers/Required.cs
+++ b/Parsinator/Parsers/Required.cs
@@ -14,9 +14,9 @@ namespace Parsinator
             this.PageNumber = p.PageNumber;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; private set; }
-        public Func<String> Default
+        public string Key { get; private set; }
+        public int? PageNumber { get; private set; }
+        public Func<string> Default
         {
             get
             {

--- a/Parsinator/Parsers/Validate.cs
+++ b/Parsinator/Parsers/Validate.cs
@@ -6,10 +6,10 @@ namespace Parsinator
 {
     public class Validate : IParse
     {
-        private readonly Predicate<IDictionary<String, String>> Predicate;
+        private readonly Predicate<IDictionary<string, string>> Predicate;
         private readonly IParse P;
 
-        public Validate(Predicate<IDictionary<String, String>> predicate, IParse p)
+        public Validate(Predicate<IDictionary<string, string>> predicate, IParse p)
         {
             this.Predicate = predicate;
             this.P = p;
@@ -18,9 +18,9 @@ namespace Parsinator
             this.Default = p.Default;
         }
 
-        public String Key { get; private set; }
-        public Int32? PageNumber { get; }
-        public Func<String> Default { get; private set; }
+        public string Key { get; private set; }
+        public int? PageNumber { get; }
+        public Func<string> Default { get; private set; }
         public bool HasMatched { get; private set; }
 
         public IDictionary<string, string> Parse(string line, int lineNumber, int lineNumberFromBottom)

--- a/Parsinator/Skippers/SkipBeforeRegexAndAfterRegex.cs
+++ b/Parsinator/Skippers/SkipBeforeRegexAndAfterRegex.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Linq;
 
@@ -12,11 +11,11 @@ namespace Parsinator
 
         public SkipBeforeRegexAndAfterRegex(Regex before, Regex after)
         {
-            this.Before = before;
-            this.After = after;
+            Before = before;
+            After = after;
         }
 
-        public List<List<String>> Skip(List<List<String>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.SkipWhile(t => !Before.IsMatch(t))
                                              // To skip the regex match itself

--- a/Parsinator/Skippers/SkipBlankLines.cs
+++ b/Parsinator/Skippers/SkipBlankLines.cs
@@ -5,7 +5,7 @@ namespace Parsinator
 {
     public class SkipBlankLines : ISkip
     {
-        public List<List<string>> Skip(List<List<string>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.Where(t => !string.IsNullOrEmpty(t))
                                              .ToList())

--- a/Parsinator/Skippers/SkipFromFirstMatchOfRegex.cs
+++ b/Parsinator/Skippers/SkipFromFirstMatchOfRegex.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -11,10 +10,10 @@ namespace Parsinator
 
         public SkipFromFirstMatchOfRegex(Regex pattern)
         {
-            this.Pattern = pattern;
+            Pattern = pattern;
         }
 
-        public List<List<String>> Skip(List<List<String>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.TakeWhile(t => !Pattern.IsMatch(t))
                                              .ToList())

--- a/Parsinator/Skippers/SkipFromFirstRegexToLastRegex.cs
+++ b/Parsinator/Skippers/SkipFromFirstRegexToLastRegex.cs
@@ -15,7 +15,7 @@ namespace Parsinator
             Last = last;
         }
 
-        public List<List<string>> Skip(List<List<string>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.TakeWhile(t => !First.IsMatch(t))
                                              .Union(l.SkipWhile(t => !Last.IsMatch(t))

--- a/Parsinator/Skippers/SkipIfDoesNotMatch.cs
+++ b/Parsinator/Skippers/SkipIfDoesNotMatch.cs
@@ -10,10 +10,10 @@ namespace Parsinator
 
         public SkipIfDoesNotMatch(Regex pattern)
         {
-            this.Pattern = pattern;
+            Pattern = pattern;
         }
 
-        public List<List<string>> Skip(List<List<string>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.Where(t => Pattern.IsMatch(t)).ToList())
                                .ToList();

--- a/Parsinator/Skippers/SkipIfMatches.cs
+++ b/Parsinator/Skippers/SkipIfMatches.cs
@@ -10,10 +10,10 @@ namespace Parsinator
 
         public SkipIfMatches(Regex pattern)
         {
-            this.Pattern = pattern;
+            Pattern = pattern;
         }
 
-        public List<List<string>> Skip(List<List<string>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.Where(t => !Pattern.IsMatch(t)).ToList())
                                .ToList();

--- a/Parsinator/Skippers/SkipLineCountFromEnd.cs
+++ b/Parsinator/Skippers/SkipLineCountFromEnd.cs
@@ -9,12 +9,12 @@ namespace Parsinator
 
         public SkipLineCountFromEnd(int lineCount = 1)
         {
-            this.LineCount = lineCount;
+            LineCount = lineCount;
         }
 
-        public List<List<string>> Skip(List<List<string>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
-            var skipped = lines.Select(l => l.Take(l.Count - LineCount).ToList())
+            var skipped = lines.Select(l => l.Take(l.Count() - LineCount).ToList())
                                .ToList();
             return skipped;
         }

--- a/Parsinator/Skippers/SkipLineCountFromLineNumber.cs
+++ b/Parsinator/Skippers/SkipLineCountFromLineNumber.cs
@@ -15,7 +15,7 @@ namespace Parsinator
             LineCount = lineCount;
         }
 
-        public List<List<string>> Skip(List<List<string>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.Take(LineNumber - 1)
                                              .Skip(LineCount)

--- a/Parsinator/Skippers/SkipLineCountFromStart.cs
+++ b/Parsinator/Skippers/SkipLineCountFromStart.cs
@@ -9,10 +9,10 @@ namespace Parsinator
 
         public SkipLineCountFromStart(int lineCount = 1)
         {
-            this.LineCount = lineCount;
+            LineCount = lineCount;
         }
 
-        public List<List<string>> Skip(List<List<string>> lines)
+        public IEnumerable<IEnumerable<string>> Skip(IEnumerable<IEnumerable<string>> lines)
         {
             var skipped = lines.Select(l => l.Skip(LineCount).ToList())
                                .ToList();

--- a/Parsinator/Transformations/TransformFromMultipleSkips.cs
+++ b/Parsinator/Transformations/TransformFromMultipleSkips.cs
@@ -1,23 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Parsinator.Transformers
 {
     public class TransformFromMultipleSkips : ITransform
     {
-        private readonly IList<ISkip> ToSkip;
+        private readonly IEnumerable<ISkip> ToSkip;
 
-        public TransformFromMultipleSkips(IList<ISkip> skippers)
+        public TransformFromMultipleSkips(IEnumerable<ISkip> skippers)
         {
             ToSkip = skippers;
         }
 
-        public List<string> Transform(List<List<string>> allPages)
+        public IEnumerable<string> Transform(IEnumerable<IEnumerable<string>> allPages)
         {
-            List<String> details = ToSkip.Chain(allPages)
-                                         .SelectMany(t => t)
-                                         .ToList();
+            var details = ToSkip.Chain(allPages)
+                                .SelectMany(t => t)
+                                .ToList();
+
             return details;
         }
     }

--- a/Parsinator/Transformations/TransformFromSingleSkip.cs
+++ b/Parsinator/Transformations/TransformFromSingleSkip.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Parsinator
@@ -10,14 +9,15 @@ namespace Parsinator
 
         public TransformFromSingleSkip(ISkip skip)
         {
-            this.ToSkip = skip;
+            ToSkip = skip;
         }
 
-        public List<string> Transform(List<List<string>> allPages)
+        public IEnumerable<string> Transform(IEnumerable<IEnumerable<string>> allPages)
         {
-            List<String> details = ToSkip.Skip(allPages)
-                                         .SelectMany(t => t)
-                                         .ToList();
+            var details = ToSkip.Skip(allPages)
+                                .SelectMany(t => t)
+                                .ToList();
+
             return details;
         }
     }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var lines = new List<List<string>>
     }
 };
 
-var parsers = new Dictionary<string, IList<IParser>>
+var parsers = new Dictionary<string, IEnumerable<IParser>>
 {
     {
         "PersonalData",
@@ -66,7 +66,7 @@ Alternatively, Parsinator has a fluent API to create skippers and parsers. Refer
 ```csharp
 using Parsinator.Fluent;
 
-var parsers = new Dictionary<string, IList<IParser>>
+var parsers = new Dictionary<string, IEnumerable<IParser>>
 {
     {
         "PersonalData",


### PR DESCRIPTION
It replaces `IList` and `List` with `IEnumerable` in Parsinator objects. No major logic changes.